### PR TITLE
zos: rebase and apply custom compile flags to support Node v12 and v14

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,11 +21,11 @@
       ['OS=="mac"', {
         'javaver%' : "<!(awk -F/ -v h=`node findJavaHome.js` 'BEGIN {n=split(h, a); print a[2]; exit}')"
       }],
-      ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
+      ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" or OS=="zos"', {
         'javalibdir%': "<!(./find_java_libdir.sh <(target_arch) <(OS))"
       }],
       ['OS=="zos"', {
-        'nodever%': '<!(node -e "console.log(process.versions.node)" | cut -d"." -f1)',
+        'nodever%': '<!(node -e "console.log(process.versions.node)" | cut -d"." -f1)'
       }],
     ]
   },
@@ -117,6 +117,9 @@
                   'cflags': [ "-U_VARARG_EXT_" ],
                 }
               ]
+            ],
+            'libraries': [
+              '<(javalibdir)/libjvm.x'
             ]
           }
         ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,7 @@
       ['OS=="win"', {
         'javahome%': '<!(node findJavaHome.js)'
       }],
-      ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"'  , {
+      ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" or OS=="zos"'  , {
         'javahome%': '<!(node findJavaHome.js)'
       }],
       ['OS=="mac"', {

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,9 @@
       ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'javalibdir%': "<!(./find_java_libdir.sh <(target_arch) <(OS))"
       }],
+      ['OS=="zos"', {
+        'nodever%': '<!(node -e "console.log(process.versions.node)" | cut -d"." -f1)',
+      }],
     ]
   },
   'targets': [
@@ -101,9 +104,22 @@
             ]
           }
         ],
-        ["OS=='zos'", {
-          "cflags!": [ "-O2", "-O3" ]
-        }],
+        ['OS=="zos"',
+          {
+            'conditions': [
+              ['nodever<14',
+                {
+                  'cflags!': [ "-O2", "-O3" ]
+                }
+              ],
+              ['nodever<12',
+                {
+                  'cflags': [ "-U_VARARG_EXT_" ],
+                }
+              ]
+            ]
+          }
+        ],
         ['OS=="mac"',
           {
             'xcode_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,7 @@
         'javahome%': '<!(node findJavaHome.js)'
       }],
       ['OS=="mac"', {
-      	'javaver%' : "<!(awk -F/ -v h=`node findJavaHome.js` 'BEGIN {n=split(h, a); print a[2]; exit}')"
+        'javaver%' : "<!(awk -F/ -v h=`node findJavaHome.js` 'BEGIN {n=split(h, a); print a[2]; exit}')"
       }],
       ['OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="openbsd" or OS=="solaris"', {
         'javalibdir%': "<!(./find_java_libdir.sh <(target_arch) <(OS))"
@@ -101,6 +101,9 @@
             ]
           }
         ],
+        ["OS=='zos'", {
+          "cflags!": [ "-O2", "-O3" ]
+        }],
         ['OS=="mac"',
           {
             'xcode_settings': {

--- a/find_java_libdir.sh
+++ b/find_java_libdir.sh
@@ -23,7 +23,7 @@ main () {
   fi
 
   local jre_dir
-  if [[ "${java_version}" =~ (6|7|8) ]]; then
+  if [[ "${java_version}" =~ (6|7|8) && "${os}" != "zos" ]]; then
     jre_dir="${java_home}/jre/lib"
   else
     jre_dir="${java_home}/lib"
@@ -43,6 +43,8 @@ main () {
     if [[ -d ${jre_dir}/amd64/classic ]]; then lib_dir="${jre_dir}"/amd64/classic; else lib_dir="${jre_dir}"/amd64/server; fi
   elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "s390x" || "${target_arch}" == "s390" ]]; then
     if [[ -d ${jre_dir}/s390x/classic ]]; then lib_dir="${jre_dir}"/s390x/classic; else lib_dir="${jre_dir}"/s390/classic; fi
+  elif [[ "${os}" == "zos" ]]; then
+    lib_dir="${jre_dir}"/s390x/classic
   elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "ppc64" || "${target_arch}" == "ppc" ]]; then
     target_arch=`uname -m`
     if [[ -d ${jre_dir}/${target_arch}/classic ]]; then lib_dir="${jre_dir}"/${target_arch}/classic; else lib_dir="${jre_dir}"/${target_arch}/server; fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "java",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -689,9 +689,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -1094,7 +1094,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -1127,7 +1127,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jvm",
     "bridge"
   ],
-  "version": "0.12.0",
+  "version": "0.12.1",
   "engines": {
     "node": ">=7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jvm",
     "bridge"
   ],
-  "version": "0.11.1",
+  "version": "0.12.0",
   "engines": {
     "node": ">=7.0.0"
   },

--- a/src/java.cpp
+++ b/src/java.cpp
@@ -203,7 +203,7 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
         classPath << ":";
       #endif
     }
-    v8::Local<v8::Value> arrayItemValue = classPathArrayTemp->Get(i);
+    v8::Local<v8::Value> arrayItemValue = classPathArrayTemp->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
     if(!arrayItemValue->IsString()) {
       return Nan::TypeError("Classpath must only contain strings");
     }
@@ -231,7 +231,7 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
   //printf("classPath: %s\n", classPath.str().c_str());
   vmOptions[0].optionString = strdup(classPath.str().c_str());
   for(uint32_t i=0; i<optionsArrayTemp->Length(); i++) {
-    v8::Local<v8::Value> arrayItemValue = optionsArrayTemp->Get(i);
+    v8::Local<v8::Value> arrayItemValue = optionsArrayTemp->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
     if(!arrayItemValue->IsString()) {
       delete[] vmOptions;
       return Nan::TypeError("options must only contain strings");
@@ -769,7 +769,7 @@ NAN_METHOD(Java::newArray) {
   if(strcmp(className.c_str(), "byte") == 0) {
     results = env->NewByteArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass byteClazz = env->FindClass("java/lang/Byte");
       jmethodID byte_byteValue = env->GetMethodID(byteClazz, "byteValue", "()B");
@@ -783,7 +783,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "char") == 0) {
     results = env->NewCharArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass stringClazz = env->FindClass("java/lang/String");
       jmethodID string_charAt = env->GetMethodID(stringClazz, "charAt", "(I)C");
@@ -797,7 +797,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "short") == 0) {
     results = env->NewShortArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass shortClazz = env->FindClass("java/lang/Short");
       jmethodID short_shortValue = env->GetMethodID(shortClazz, "shortValue", "()S");
@@ -811,7 +811,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "double") == 0) {
     results = env->NewDoubleArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass doubleClazz = env->FindClass("java/lang/Double");
       jmethodID double_doubleValue = env->GetMethodID(doubleClazz, "doubleValue", "()D");
@@ -825,7 +825,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "int") == 0) {
     results = env->NewIntArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass integerClazz = env->FindClass("java/lang/Integer");
       jmethodID integer_intValue = env->GetMethodID(integerClazz, "intValue", "()I");
@@ -839,7 +839,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "float") == 0) {
     results = env->NewFloatArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass floatClazz = env->FindClass("java/lang/Float");
       jmethodID float_floatValue = env->GetMethodID(floatClazz, "floatValue", "()F");
@@ -853,7 +853,7 @@ NAN_METHOD(Java::newArray) {
   else if(strcmp(className.c_str(), "boolean") == 0) {
     results = env->NewBooleanArray(arrayObj->Length());
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       jclass booleanClazz = env->FindClass("java/lang/Boolean");
       jmethodID boolean_booleanValue = env->GetMethodID(booleanClazz, "booleanValue", "()Z");
@@ -877,7 +877,7 @@ NAN_METHOD(Java::newArray) {
     results = env->NewObjectArray(arrayObj->Length(), clazz, NULL);
 
     for(uint32_t i=0; i<arrayObj->Length(); i++) {
-      v8::Local<v8::Value> item = arrayObj->Get(i);
+      v8::Local<v8::Value> item = arrayObj->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
       jobject val = v8ToJava(env, item);
       env->SetObjectArrayElement((jobjectArray)results, i, val);
       if(env->ExceptionOccurred()) {
@@ -1251,7 +1251,7 @@ void EIO_AfterCallJs(uv_work_t* req) {
   jobject javaResult;
 
   v8::Local<v8::Object> dynamicProxyDataFunctions = Nan::New(dynamicProxyData->functions);
-  v8::Local<v8::Value> fnObj = dynamicProxyDataFunctions->Get(Nan::New<v8::String>(dynamicProxyData->methodName.c_str()).ToLocalChecked());
+  v8::Local<v8::Value> fnObj = dynamicProxyDataFunctions->Get(Nan::GetCurrentContext(), Nan::New<v8::String>(dynamicProxyData->methodName.c_str()).ToLocalChecked()).ToLocalChecked();
   if(fnObj->IsUndefined() || fnObj->IsNull()) {
     dynamicProxyData->throwableClass = "java/lang/NoSuchMethodError";
     dynamicProxyData->throwableMessage = "Could not find js function " + dynamicProxyData->methodName;
@@ -1275,7 +1275,7 @@ void EIO_AfterCallJs(uv_work_t* req) {
   }
   argv = new v8::Local<v8::Value>[argc];
   for(i=0; i<argc; i++) {
-    argv[i] = v8Args->Get(i);
+    argv[i] = v8Args->Get(Nan::GetCurrentContext(), i).ToLocalChecked();
   }
 
   Nan::TryCatch tryCatch;

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -29,8 +29,8 @@
 
   v8::Local<v8::Function> promisify;
   if(java->DoPromise()) {
-    v8::Local<v8::Object> asyncOptions = java->handle()->Get(Nan::New<v8::String>("asyncOptions").ToLocalChecked()).As<v8::Object>();
-    v8::Local<v8::Value> promisifyValue = asyncOptions->Get(Nan::New<v8::String>("promisify").ToLocalChecked());
+    v8::Local<v8::Object> asyncOptions = java->handle()->Get(Nan::GetCurrentContext(), Nan::New<v8::String>("asyncOptions").ToLocalChecked()).ToLocalChecked().As<v8::Object>();
+    v8::Local<v8::Value> promisifyValue = asyncOptions->Get(Nan::GetCurrentContext(), Nan::New<v8::String>("promisify").ToLocalChecked()).ToLocalChecked();
     promisify = promisifyValue.As<v8::Function>();
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -484,7 +484,11 @@ jvalueType javaGetArrayComponentType(JNIEnv *env, jobjectArray array) {
 #if (NODE_VERSION_AT_LEAST(4, 0, 0))
 v8::Local<v8::ArrayBuffer> newArrayBuffer(void* elems, size_t length) {
   v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), length);
+#if (V8_MAJOR_VERSION >= 8)
+  memcpy(ab->GetBackingStore()->Data(), elems, length);
+#else
   memcpy(ab->GetContents().Data(), elems, length);
+#endif
   return ab;
 }
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,13 +37,17 @@ struct DynamicProxyData {
   std::string interfaceName;
   Nan::Persistent<v8::Object> functions;
   Nan::Persistent<v8::Value> jsObject;
+  unsigned int markerEnd;
+};
+
+struct DynamicProxyJsCallData {
+  DynamicProxyData *dynamicProxyData;
   std::string methodName;
   jobjectArray args;
   jobject result;
   std::string throwableClass;
   std::string throwableMessage;
   int done;
-  unsigned int markerEnd;
 };
 
 #define DYNAMIC_PROXY_DATA_MARKER_START 0x12345678


### PR DESCRIPTION
This PR merges current latest https://github.com/joeferner/node-java/commit/bc557ad101909990e2d4c1c257989842a06d5ac4 with https://github.com/ibmruntimes/node-java/commit/11d557d1b7f68409e3abb10f8bf421166105f54e and updates binding.gyp to enable node-java to be build with v12 and v14 without explicitly settings compiler flags, as follows:

- v8 (ships with D190508), requires -U_VARARG_EXT_ and no-opt
- v12 (ships with D191122), requires no-opt
- v14 (ships with D191122), no workaround needed (note `npm test` actually fails with no-opt)

The latest version from joeferne is required to resolve v8 API incompatibility issues with v8 (8.1) from Node v14.

It also converts GetContents() to GetBackingStore() for Node versions 8 and up.

The `package.json` from node-jdbc (https://github.com/ibmruntimes/node-jdbc/tree/zos) still needs to be updated to replace dependency:
   "java": "git+https://github.com/ibmruntimes/node-java.git#node12-zos",
by:
   "java": "git+https://github.com/ibmruntimes/node-java.git#node14-zos",