### PR TITLE
src: verify pointer before calling its method

### DIFF
--- a/src/methodCallBaton.cpp
+++ b/src/methodCallBaton.cpp
@@ -236,5 +236,8 @@ InstanceMethodCallBaton::InstanceMethodCallBaton(
 }
 
 InstanceMethodCallBaton::~InstanceMethodCallBaton() {
-  m_javaObject->Unref();
+  if (m_javaObject) {
+    m_javaObject->Unref();
+    m_javaObject = NULL;
+  }
 }


### PR DESCRIPTION
The destructor InstanceMethodCallBaton() calls m_javaObject->Unref() which aborts when m_javaObject is NULL.

Affects at least `npm test` from `node-jdbc` npm, which aborts in test `test-statement-adjust / testcreatetable`:

(abort) [0x26C7C640]
(__cxa_end_catch) [0x2E2CC414]
(InstanceMethodCallBaton::~InstanceMethodCallBaton()+0x140) [0x2E2CD2A4]
(Nan::AsyncWorker::Destroy()@AF61_58+0x28) [0x2E2CCE4C]
(Nan::AsyncWorker::Destroy()+0x18) [0x2E2C9F12]
(Nan::AsyncExecuteComplete(uv_work_s*)+0x4e) [0x27DB5430]
...